### PR TITLE
There is now a base "get" helper.

### DIFF
--- a/src/helpers/default.rs
+++ b/src/helpers/default.rs
@@ -1,0 +1,37 @@
+use std::sync::Mutex;
+
+use actix_web::web::Data;
+use handlebars::{Context, Handlebars, Helper, JsonRender, Output, RenderContext, RenderError};
+
+fn get(
+    h: &Helper,
+    _: &Handlebars,
+    ctx: &Context,
+    _: &mut RenderContext,
+    out: &mut dyn Output,
+) -> Result<(), RenderError> {
+    let module_title = h
+        .param(0)
+        .ok_or(RenderError::new(
+            "No module title provided to helper function.",
+        ))?
+        .render();
+    out.write(
+        &ctx.data()
+            .get("fields")
+            .unwrap()
+            .get(module_title.clone())
+            .unwrap()
+            .get("content")
+            .unwrap()
+            .render(),
+    )?;
+    Ok(())
+}
+
+pub fn register_helpers(handlebars: Data<Mutex<Handlebars<'_>>>) {
+    handlebars
+        .lock()
+        .unwrap()
+        .register_helper("get", Box::new(get));
+}

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod default;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod models;
 mod routers;
 mod schema;
 mod watch;
+mod helpers;
 
 #[cfg(test)]
 mod tests;
@@ -37,6 +38,8 @@ async fn main() -> std::io::Result<()> {
     // web::Data is Arc, so we can safely clone it and send it between our watcher and the server.
     let handlebars_ref = web::Data::new(Mutex::new(handlebars));
     let hb = handlebars_ref.clone();
+    
+    helpers::default::register_helpers(hb.clone());
 
     std::thread::spawn(|| watch::watch(hb));
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,8 @@
 
 <body>
     <h1>{{ page_title }}</h1>
-    <h1>yeet {{ page_url }}</h1>
+    <p>{{get "title"}}</p>
+    <small>{{get "small"}}</small>
 </body>
 
 </html>


### PR DESCRIPTION
There is now a `get` helper function that allows template developers to get dynamic code based on data in the database.

Still need to provide some sort of spec sheet, so developers know what variables are present for use. Closes #10.