### PR TITLE
No fields present

### DIFF
--- a/src/controllers/page_controllers.rs
+++ b/src/controllers/page_controllers.rs
@@ -13,8 +13,8 @@ use crate::models::page_models::{MutPage, Page};
 use crate::middleware::errors_middleware::{map_sql_error, CustomHttpError};
 use crate::middleware::response_middleware::HttpResponseBuilder;
 
-fn parse_page(page_vec: Vec<(Page, Module)>) -> Result<PageModuleRelation, CustomHttpError> {
-    let origin_page = &page_vec.get(0).ok_or(CustomHttpError::NotFound)?.0;
+fn parse_page(page: (Page, Vec<Module>)) -> Result<PageModuleRelation, CustomHttpError> {
+    let origin_page = page.0;
 
     // cast the origin page that is always standard into a new object that has the modules as a vec of children.
     let mut res = PageModuleRelation {
@@ -26,9 +26,7 @@ fn parse_page(page_vec: Vec<(Page, Module)>) -> Result<PageModuleRelation, Custo
         page_id: origin_page.id,
     };
 
-    // Parsing of the tuples starts here.
-    for tuple in page_vec {
-        let module = tuple.1;
+    for module in page.1 {
         res.fields.insert(module.title.clone(), module);
     }
 
@@ -42,15 +40,22 @@ pub async fn display_page(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
     let path = req.path();
-    let page_vec = Page::read_one_join_on(path.to_string(), &mysql_pool).map_err(map_sql_error)?;
+    let page_tuple = Page::read_one_join_on(path.to_string(), &mysql_pool).map_err(map_sql_error)?;
     // Parse it in to one single page.
-    let pagemodule = parse_page(page_vec)?;
+    let pagemodule = parse_page(page_tuple)?;
 
     // TODO this should only happen on request of template reload. maybe add a path to config?
     hb.lock().unwrap().clear_templates();
-    hb.lock().unwrap().register_templates_directory(".html", "./templates").unwrap();
-    
-    let s = hb.lock().unwrap().render(&pagemodule.page_name, &pagemodule).unwrap();
+    hb.lock()
+        .unwrap()
+        .register_templates_directory(".html", "./templates")
+        .unwrap();
+
+    let s = hb
+        .lock()
+        .unwrap()
+        .render(&pagemodule.page_name, &pagemodule)
+        .unwrap();
 
     Ok(HttpResponse::Ok().content_type("text/html").body(s))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ async fn main() -> std::io::Result<()> {
     let handlebars_ref = web::Data::new(Mutex::new(handlebars));
     let hb = handlebars_ref.clone();
     
-    helpers::default::register_helpers(hb.clone());
+    helpers::default::register_helpers(handlebars_ref.clone());
 
     std::thread::spawn(|| watch::watch(hb));
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -33,7 +33,7 @@ pub trait Joinable<TLeft, TRight, TPrimary> {
     fn read_one_join_on(
         id: TPrimary,
         db: &MysqlConnection,
-    ) -> Result<Vec<(TLeft, TRight)>, diesel::result::Error>;
+    ) -> Result<(TLeft, Vec<TRight>), diesel::result::Error>;
 }
 
 pub fn establish_database_connection() -> Option<MySQLPool> {

--- a/src/models/module_models.rs
+++ b/src/models/module_models.rs
@@ -3,9 +3,13 @@ use diesel::{Insertable, Queryable, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 
 use super::Model;
+use super::page_models::Page;
 use crate::schema::modules;
 
-#[derive(Debug, Serialize, Deserialize, Queryable, PartialEq, Clone, Eq, Hash)]
+#[derive(Debug, Identifiable, Associations, Serialize, Deserialize, Queryable, PartialEq, Clone, Eq, Hash)]
+#[belongs_to(Page)]
+#[primary_key(module_id)]
+#[table_name = "modules"]
 pub struct Module {
     pub module_id: i32,
     pub module_type_id: i32,


### PR DESCRIPTION
Added associations to the Joinable trait implementation on Page so that it wouldn't fail on `inner_join`. Inner join used to return nothing if there were no modules, but now it returns just the page with no modules. This is more idiomatic.