### PR TITLE
Add extractors to functions instead of self-parsing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Version: Pre-alpha
 
 Currently this project has no frontend and is just a backend API.
 
+## Note on testing
+
+Whenever you run the tests, it is best to have a clean database.
+
+You **MUST** run it using this command (since mocking for Diesel isn't mature yet):
+
+`cargo test -- --test-thread=1`
+
 ## Dev Environment Setup
 
 Required items:

--- a/src/controllers/config_controllers.rs
+++ b/src/controllers/config_controllers.rs
@@ -1,5 +1,5 @@
 use crate::models::config_models::{Config, MutConfig};
-use actix_web::{web, HttpRequest, HttpResponse};
+use actix_web::{web, HttpResponse};
 use serde::{Deserialize, Serialize};
 
 use std::{
@@ -58,30 +58,20 @@ pub async fn read_all_database_config(
 }
 
 pub async fn read_one_database_config(
-    req: HttpRequest,
+    id: web::Path<i32>,
     pool: web::Data<MySQLPool>,
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
-    let config_id: String = req
-        .match_info()
-        .get("id")
-        .ok_or(CustomHttpError::BadRequest)?
-        .to_owned();
-    let one = Config::read_one(config_id, &mysql_pool).map_err(map_sql_error)?;
+    let one = Config::read_one(id.to_string(), &mysql_pool).map_err(map_sql_error)?;
     HttpResponseBuilder::new(200, &one)
 }
 
 pub async fn update_database_config(
-    req: HttpRequest,
+    id: web::Path<i32>,
     pool: web::Data<MySQLPool>,
     mut_config: web::Json<MutConfig>,
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
-    let config_id: String = req
-        .match_info()
-        .get("id")
-        .ok_or(CustomHttpError::BadRequest)?
-        .to_owned();
-    let us = Config::update(config_id, &mut_config, &mysql_pool).map_err(map_sql_error)?;
+    let us = Config::update(id.to_string(), &mut_config, &mysql_pool).map_err(map_sql_error)?;
     HttpResponseBuilder::new(200, &us)
 }

--- a/src/controllers/module_controllers.rs
+++ b/src/controllers/module_controllers.rs
@@ -1,9 +1,8 @@
-use actix_web::{web, HttpRequest, HttpResponse};
+use actix_web::{web, HttpResponse};
 
 use crate::models::{Model, MySQLPool, pool_handler};
 use crate::models::module_models::{Module, MutModule};
 
-use crate::middleware::errors_middleware::map_int_parsing_error;
 use crate::middleware::errors_middleware::map_sql_error;
 use crate::middleware::errors_middleware::CustomHttpError;
 
@@ -11,16 +10,14 @@ use crate::middleware::response_middleware::HttpResponseBuilder;
 
 /// Creates a module by passing a module-like JSON object.
 pub async fn create_module(
-    req_body: String,
+    new_module: web::Json<MutModule>,
     pool: web::Data<MySQLPool>,
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
-    let new_module: MutModule =
-        serde_json::from_str(&req_body).or(Err(CustomHttpError::BadRequest))?;
 
     Module::create(&new_module, &mysql_pool).map_err(map_sql_error)?;
 
-    HttpResponseBuilder::new(201, &new_module)
+    HttpResponseBuilder::new(201, &*new_module)
 }
 
 /// Gets all modules.
@@ -33,57 +30,37 @@ pub async fn get_modules(pool: web::Data<MySQLPool>) -> Result<HttpResponse, Cus
 
 /// Gets one module by passing a module ID.
 pub async fn get_module(
-    req: HttpRequest,
+    id: web::Path<i32>,
     pool: web::Data<MySQLPool>,
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
-    let module_id: i32 = req
-        .match_info()
-        .get("id")
-        .ok_or(CustomHttpError::BadRequest)?
-        .parse()
-        .map_err(map_int_parsing_error)?;
 
-    let module = Module::read_one(module_id, &mysql_pool).map_err(map_sql_error)?;
+    let module = Module::read_one(*id, &mysql_pool).map_err(map_sql_error)?;
 
     HttpResponseBuilder::new(200, &module)
 }
 
 /// Updates a module by passing a module-like JSON object and a module ID.
 pub async fn update_module(
-    req_body: String,
-    req: HttpRequest,
+    updated_module: web::Json<MutModule>,
+    id: web::Path<i32>,
     pool: web::Data<MySQLPool>,
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
-    let new_module: MutModule =
-        serde_json::from_str(&req_body).or(Err(CustomHttpError::BadRequest))?;
-    let module_id: i32 = req
-        .match_info()
-        .get("id")
-        .ok_or(CustomHttpError::BadRequest)?
-        .parse()
-        .map_err(map_int_parsing_error)?;
 
-    Module::update(module_id, &new_module, &mysql_pool).map_err(map_sql_error)?;
+    Module::update(*id, &updated_module, &mysql_pool).map_err(map_sql_error)?;
 
-    HttpResponseBuilder::new(200, &new_module)
+    HttpResponseBuilder::new(200, &*updated_module)
 }
 
 /// Deletes a module by passing a module ID.
 pub async fn delete_module(
-    req: HttpRequest,
+    id: web::Path<i32>,
     pool: web::Data<MySQLPool>,
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
-    let module_id: i32 = req
-        .match_info()
-        .get("id")
-        .ok_or(CustomHttpError::BadRequest)?
-        .parse()
-        .map_err(map_int_parsing_error)?;
 
-    Module::delete(module_id, &mysql_pool).map_err(map_sql_error)?;
+    Module::delete(*id, &mysql_pool).map_err(map_sql_error)?;
 
-    HttpResponseBuilder::new(200, &format!("Successfully deleted resource {}", module_id))
+    HttpResponseBuilder::new(200, &format!("Successfully deleted resource {}", id))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(int_error_matching)]
 #![feature(try_blocks)]
 
 use std::sync::{Mutex};

--- a/src/middleware/errors_middleware.rs
+++ b/src/middleware/errors_middleware.rs
@@ -53,14 +53,6 @@ impl ResponseError for CustomHttpError {
     }
 }
 
-/// Used whenever parsing ints out of the URLs.
-pub fn map_int_parsing_error(e: std::num::ParseIntError) -> CustomHttpError {
-    match e.kind() {
-        std::num::IntErrorKind::InvalidDigit => CustomHttpError::BadRequest,
-        _ => CustomHttpError::Unknown,
-    }
-}
-
 /// Any time an SQL query fails, it gets mapped to here.
 pub fn map_sql_error(e: diesel::result::Error) -> CustomHttpError {
     match e {

--- a/src/models/module_models.rs
+++ b/src/models/module_models.rs
@@ -21,6 +21,7 @@ pub struct Module {
 #[derive(Insertable, AsChangeset, Deserialize, Serialize)]
 #[table_name = "modules"]
 pub struct MutModule {
+    pub module_id: Option<i32>,
     pub module_type_id: i32,
     pub title: String,
     pub page_id: i32,

--- a/src/models/page_models.rs
+++ b/src/models/page_models.rs
@@ -26,6 +26,8 @@ pub struct Page {
 #[derive(Insertable, AsChangeset, Deserialize, Serialize)]
 #[table_name = "pages"]
 pub struct MutPage {
+    pub id: Option<i32>,
+    pub page_name: String,
     pub page_url: String,
     pub page_title: String,
 }


### PR DESCRIPTION
Extractors should be used over self-parsing as Actix-web handles it wonderfully.

Unit tests were also updated. These still need to be updated to do real mock queries rather than calling functions directly.

Closes #5 