### PR TITLE
404 generic handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Version: Pre-alpha
 |             | Ready |
 | ----------- | ----------- |
 | Backend | ✅ |
-| Frontend | - |
+| Frontend | ✅ |
 | Production | ❌ |
 
-Currently this project has no frontend and is just a backend API.
+This project has a functioning frontend, but it is not fully featured yet.
 
 ## Note on testing
 
@@ -92,9 +92,11 @@ Most all environment setup will be handled by an installer GUI in the future. Fo
 }
 ```
 
+## Notes on 404 Pages
+
+404s are handled (currently) by creating a file called `404.html.` It will automatically be added as your 404 page.
+
 ## Repositories Like This
-
-
 
 Markdown static site generators:
 

--- a/src/controllers/config_controllers.rs
+++ b/src/controllers/config_controllers.rs
@@ -9,7 +9,7 @@ use std::{
 
 use crate::models::Model;
 
-use crate::middleware::errors_middleware::{map_sql_error, CustomHttpError};
+use crate::middleware::errors_middleware::CustomHttpError;
 use crate::middleware::response_middleware::HttpResponseBuilder;
 
 use crate::models::{pool_handler, MySQLPool};
@@ -53,7 +53,7 @@ pub async fn read_all_database_config(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
 
-    let all = Config::read_all(&mysql_pool).map_err(map_sql_error)?;
+    let all = Config::read_all(&mysql_pool)?;
     HttpResponseBuilder::new(200, &all)
 }
 
@@ -62,7 +62,7 @@ pub async fn read_one_database_config(
     pool: web::Data<MySQLPool>,
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
-    let one = Config::read_one(id.to_string(), &mysql_pool).map_err(map_sql_error)?;
+    let one = Config::read_one(id.to_string(), &mysql_pool)?;
     HttpResponseBuilder::new(200, &one)
 }
 
@@ -72,6 +72,6 @@ pub async fn update_database_config(
     mut_config: web::Json<MutConfig>,
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
-    let us = Config::update(id.to_string(), &mut_config, &mysql_pool).map_err(map_sql_error)?;
+    let us = Config::update(id.to_string(), &mut_config, &mysql_pool)?;
     HttpResponseBuilder::new(200, &us)
 }

--- a/src/controllers/module_controllers.rs
+++ b/src/controllers/module_controllers.rs
@@ -3,7 +3,6 @@ use actix_web::{web, HttpResponse};
 use crate::models::{Model, MySQLPool, pool_handler};
 use crate::models::module_models::{Module, MutModule};
 
-use crate::middleware::errors_middleware::map_sql_error;
 use crate::middleware::errors_middleware::CustomHttpError;
 
 use crate::middleware::response_middleware::HttpResponseBuilder;
@@ -14,14 +13,14 @@ pub async fn create_module(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
 
-    Module::create(&new_module, &mysql_pool).map_err(map_sql_error)?;
+    Module::create(&new_module, &mysql_pool)?;
 
     HttpResponseBuilder::new(201, &*new_module)
 }
 
 pub async fn get_modules(pool: web::Data<MySQLPool>) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
-    let modules = Module::read_all(&mysql_pool).map_err(map_sql_error)?;
+    let modules = Module::read_all(&mysql_pool)?;
 
     HttpResponseBuilder::new(200, &modules)
 }
@@ -32,7 +31,7 @@ pub async fn get_module(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
 
-    let module = Module::read_one(*id, &mysql_pool).map_err(map_sql_error)?;
+    let module = Module::read_one(*id, &mysql_pool)?;
 
     HttpResponseBuilder::new(200, &module)
 }
@@ -44,7 +43,7 @@ pub async fn update_module(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
 
-    Module::update(*id, &updated_module, &mysql_pool).map_err(map_sql_error)?;
+    Module::update(*id, &updated_module, &mysql_pool)?;
 
     HttpResponseBuilder::new(200, &*updated_module)
 }
@@ -55,7 +54,7 @@ pub async fn delete_module(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
 
-    Module::delete(*id, &mysql_pool).map_err(map_sql_error)?;
+    Module::delete(*id, &mysql_pool)?;
 
     HttpResponseBuilder::new(200, &format!("Successfully deleted resource {}", id))
 }

--- a/src/controllers/page_controllers.rs
+++ b/src/controllers/page_controllers.rs
@@ -10,7 +10,7 @@ use crate::models::module_models::Module;
 use crate::models::page_models::PageModuleRelation;
 use crate::models::page_models::{MutPage, Page};
 
-use crate::middleware::errors_middleware::{map_sql_error, CustomHttpError};
+use crate::middleware::errors_middleware::CustomHttpError;
 use crate::middleware::response_middleware::HttpResponseBuilder;
 
 fn parse_page(page: (Page, Vec<Module>)) -> Result<PageModuleRelation, CustomHttpError> {
@@ -40,11 +40,21 @@ pub async fn display_page(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
     let path = req.path();
-    let page_tuple = Page::read_one_join_on(path.to_string(), &mysql_pool).map_err(map_sql_error)?;
-    let pagemodule = parse_page(page_tuple)?;
-    
-    let s = hb.lock().unwrap().render(&pagemodule.page_name, &pagemodule).unwrap();
-  
+    let page_tuple = Page::read_one_join_on(path.to_string(), &mysql_pool);
+
+    if let Err(x) = page_tuple {
+        let s = hb.lock().unwrap().render("404", &String::from("")).unwrap();
+        return Ok(HttpResponse::Ok().content_type("text/html").body(s));
+    }
+
+    let pagemodule = parse_page(page_tuple?)?;
+
+    let s = hb
+        .lock()
+        .unwrap()
+        .render(&pagemodule.page_name, &pagemodule)
+        .unwrap();
+
     Ok(HttpResponse::Ok().content_type("text/html").body(s))
 }
 
@@ -54,14 +64,14 @@ pub async fn create_page(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
 
-    Page::create(&new_page, &mysql_pool).map_err(map_sql_error)?;
+    Page::create(&new_page, &mysql_pool)?;
 
     HttpResponseBuilder::new(201, &*new_page)
 }
 
 pub async fn get_pages(pool: web::Data<MySQLPool>) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
-    let pages: Vec<Page> = Page::read_all(&mysql_pool).map_err(map_sql_error)?;
+    let pages: Vec<Page> = Page::read_all(&mysql_pool)?;
 
     HttpResponseBuilder::new(200, &pages)
 }
@@ -72,7 +82,7 @@ pub async fn get_page(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
 
-    let page: Page = Page::read_one(*id, &mysql_pool).map_err(map_sql_error)?;
+    let page: Page = Page::read_one(*id, &mysql_pool)?;
 
     HttpResponseBuilder::new(200, &page)
 }
@@ -86,8 +96,7 @@ pub async fn get_page_join_modules(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
 
-    let page_vec =
-        Page::read_one_join_on(id.to_string(), &mysql_pool).map_err(map_sql_error)?;
+    let page_vec = Page::read_one_join_on(id.to_string(), &mysql_pool)?;
 
     let pagemodules = parse_page(page_vec).or(Err(CustomHttpError::NotFound))?;
 
@@ -101,7 +110,7 @@ pub async fn update_page(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
 
-    Page::update(*id, &updated_page, &mysql_pool).map_err(map_sql_error)?;
+    Page::update(*id, &updated_page, &mysql_pool)?;
 
     HttpResponseBuilder::new(200, &*updated_page)
 }
@@ -112,7 +121,7 @@ pub async fn delete_page(
 ) -> Result<HttpResponse, CustomHttpError> {
     let mysql_pool = pool_handler(pool)?;
 
-    Page::delete(*id, &mysql_pool).map_err(map_sql_error)?;
+    Page::delete(*id, &mysql_pool)?;
 
     HttpResponseBuilder::new(200, &format!("Successfully deleted resource {}", id))
 }

--- a/src/controllers/page_controllers.rs
+++ b/src/controllers/page_controllers.rs
@@ -42,7 +42,7 @@ pub async fn display_page(
     let path = req.path();
     let page_tuple = Page::read_one_join_on(path.to_string(), &mysql_pool);
 
-    if let Err(x) = page_tuple {
+    if let Err(_) = page_tuple {
         let s = hb.lock().unwrap().render("404", &String::from("")).unwrap();
         return Ok(HttpResponse::Ok().content_type("text/html").body(s));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,11 @@ async fn main() -> std::io::Result<()> {
     let handlebars_ref = web::Data::new(Mutex::new(handlebars));
     let hb = handlebars_ref.clone();
 
+    hb.lock()
+        .unwrap()
+        .register_templates_directory(".html", "./templates")
+        .unwrap();
+
     // Registers all default handlebars functions.
     helpers::default::register_helpers(handlebars_ref.clone());
 

--- a/src/middleware/errors_middleware.rs
+++ b/src/middleware/errors_middleware.rs
@@ -1,5 +1,4 @@
 use actix_web::{error::ResponseError, http::StatusCode, HttpResponse};
-
 use serde::Serialize;
 use thiserror::Error;
 /// A custom type that defines errors that are mapped to HTTP errors later.
@@ -54,9 +53,11 @@ impl ResponseError for CustomHttpError {
 }
 
 /// Any time an SQL query fails, it gets mapped to here.
-pub fn map_sql_error(e: diesel::result::Error) -> CustomHttpError {
-    match e {
-        diesel::result::Error::NotFound => CustomHttpError::NotFound,
-        _ => CustomHttpError::Unknown,
+impl From<diesel::result::Error> for CustomHttpError {
+    fn from(e: diesel::result::Error) -> Self {
+        match e {
+            diesel::result::Error::NotFound => CustomHttpError::NotFound,
+            _ => CustomHttpError::Unknown,
+        }
     }
 }

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 - Not Found</title>
+</head>
+<body>
+    <h1>Oops!</h1>
+    <small>This content wasn't found.</small>
+</body>
+</html>


### PR DESCRIPTION
Added a base 404 handler. You can now add 404 handling by creating a `404.html` file in your root of `templates`.

Also, began working on better error handling by removing `map_sql_error` for all diesel calls. It is now done through a `from<diesel::result::error>` impl on `CustomHttpError`.

Added some documentation in the README.md for this too.

Closes #14 