### PR TITLE
Dto relation replacement

### DIFF
--- a/src/controllers/module_controllers.rs
+++ b/src/controllers/module_controllers.rs
@@ -4,7 +4,6 @@ use crate::models::{Model, MySQLPool, pool_handler};
 use crate::models::module_models::{Module, MutModule};
 
 use crate::middleware::errors_middleware::CustomHttpError;
-
 use crate::middleware::response_middleware::HttpResponseBuilder;
 
 pub async fn create_module(

--- a/src/controllers/page_controllers.rs
+++ b/src/controllers/page_controllers.rs
@@ -7,17 +7,17 @@ use handlebars::Handlebars;
 use crate::models::{pool_handler, Joinable, Model, MySQLPool};
 
 use crate::models::module_models::Module;
-use crate::models::page_models::PageModuleRelation;
+use crate::models::page_models::PageModuleDTO;
 use crate::models::page_models::{MutPage, Page};
 
 use crate::middleware::errors_middleware::CustomHttpError;
 use crate::middleware::response_middleware::HttpResponseBuilder;
 
-fn parse_page(page: (Page, Vec<Module>)) -> Result<PageModuleRelation, CustomHttpError> {
+fn parse_page(page: (Page, Vec<Module>)) -> Result<PageModuleDTO, CustomHttpError> {
     let origin_page = page.0;
 
     // cast the origin page that is always standard into a new object that has the modules as a vec of children.
-    let mut res = PageModuleRelation {
+    let mut res = PageModuleDTO {
         page_name: origin_page.page_name.to_string(),
         page_url: origin_page.page_url.to_string(),
         page_title: origin_page.page_title.to_string(),

--- a/src/helpers/default.rs
+++ b/src/helpers/default.rs
@@ -1,5 +1,4 @@
 use std::sync::Mutex;
-
 use actix_web::web::Data;
 use handlebars::{Context, Handlebars, Helper, JsonRender, Output, RenderContext, RenderError};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![feature(try_blocks)]
 
 use std::sync::Mutex;
-
 use actix_cors::Cors;
 use actix_web::{web, App, HttpServer};
 use handlebars::Handlebars;

--- a/src/models/config_models.rs
+++ b/src/models/config_models.rs
@@ -3,7 +3,6 @@ use diesel::{AsChangeset, Insertable, Queryable};
 use serde::{Deserialize, Serialize};
 
 use crate::models::Model;
-
 use crate::schema::web_config;
 
 #[derive(Queryable, Deserialize, Serialize, PartialEq, Clone)]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -26,9 +26,8 @@ pub trait Model<TQueryable, TMutable, TPrimary> {
 }
 
 /// Trait that enforces a  Model to be joinable if that is desired.
-/// Usually used for inner joins in this program.
-/// If implemented another way, make sure to follow the generic labelling.
-/// First parameter MUST be the left table, and second parameter MUST be the right table.
+/// This should use associations rather than Left or Right join.
+/// https://docs.diesel.rs/diesel/associations/index.html
 pub trait Joinable<TLeft, TRight, TPrimary> {
     fn read_one_join_on(
         id: TPrimary,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -3,7 +3,6 @@ pub mod module_models;
 pub mod page_models;
 
 use std::{fs::File, io::BufReader};
-
 use actix_web::web;
 use diesel::{MysqlConnection, r2d2::{ConnectionManager, Pool, PoolError, PooledConnection}};
 

--- a/src/models/page_models.rs
+++ b/src/models/page_models.rs
@@ -1,11 +1,9 @@
 use std::collections::HashMap;
-
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use super::Joinable;
-
 use super::module_models::Module;
 use super::Model;
 use crate::schema::pages;

--- a/src/models/page_models.rs
+++ b/src/models/page_models.rs
@@ -31,7 +31,7 @@ pub struct MutPage {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct PageModuleRelation {
+pub struct PageModuleDTO {
     pub page_id: i32,
     pub page_name: String,
     pub page_url: String,


### PR DESCRIPTION
The DTO naming scheme seems to fit this better. Chose not to put these objects in a new directory since it seems like an antipattern when compared to storing them in the `modules` folder.