### PR TITLE
Allow for #each use with custom fields.

### DIFF
--- a/migrations/2020-12-18-181841_create_pages/down.sql
+++ b/migrations/2020-12-18-181841_create_pages/down.sql
@@ -1,5 +1,6 @@
 -- This file should undo anything in `up.sql`
 DROP TABLE modules;
+DROP TABLE module_category;
 DROP TABLE module_types;
 DROP TABLE pages;
 DROP TABLE web_config;

--- a/migrations/2020-12-18-181841_create_pages/up.sql
+++ b/migrations/2020-12-18-181841_create_pages/up.sql
@@ -19,17 +19,24 @@ INSERT IGNORE INTO module_types (title, module_desc) VALUES ('paragraph', 'A par
 INSERT IGNORE INTO module_types (title, module_desc) VALUES ('header', 'A header module for displaying things in large text.');
 INSERT IGNORE INTO module_types (title, module_desc) VALUES ('image', 'Allows for inserting images into the page.');
 
+CREATE TABLE module_category (
+    id int AUTO_INCREMENT PRIMARY KEY NOT NULL,
+    title varchar(100) NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS modules (
     module_id int AUTO_INCREMENT PRIMARY KEY NOT NULL,
     module_type_id int NOT NULL,
     title varchar(100) NOT NULL,
     page_id int NOT NULL,
     content TEXT NOT NULL,
+    category int,
     FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE CASCADE,
-    FOREIGN KEY (module_type_id) REFERENCES module_types(module_type_id) ON DELETE CASCADE
+    FOREIGN KEY (module_type_id) REFERENCES module_types(module_type_id) ON DELETE CASCADE,
+    FOREIGN KEY (category) REFERENCES module_category(id) ON DELETE CASCADE
 );
 
-INSERT IGNORE INTO modules (module_type_id, title, page_id, content) VALUES (1, "Hello world!", 1, "Hello world!");
+INSERT IGNORE INTO modules (module_type_id, title, page_id, content) VALUES (1, "title", 1, "Hello world!");
 
 CREATE TABLE IF NOT EXISTS web_config (
     config_key VARCHAR(100) PRIMARY KEY NOT NULL,

--- a/migrations/2020-12-18-181841_create_pages/up.sql
+++ b/migrations/2020-12-18-181841_create_pages/up.sql
@@ -24,6 +24,8 @@ CREATE TABLE module_category (
     title varchar(100) NOT NULL
 );
 
+insert ignore into module_category (title) VALUES ("colors");
+
 CREATE TABLE IF NOT EXISTS modules (
     module_id int AUTO_INCREMENT PRIMARY KEY NOT NULL,
     module_type_id int NOT NULL,
@@ -36,7 +38,11 @@ CREATE TABLE IF NOT EXISTS modules (
     FOREIGN KEY (category) REFERENCES module_category(id) ON DELETE CASCADE
 );
 
-INSERT IGNORE INTO modules (module_type_id, title, page_id, content) VALUES (1, "title", 1, "Hello world!");
+INSERT IGNORE INTO modules (module_type_id, title, page_id, content) VALUES (1, "title", 1, "This is the `title` module!!");
+INSERT IGNORE INTO modules (module_type_id, title, page_id, content) VALUES (1, "small", 1, "This is the `small` module!");
+INSERT IGNORE INTO modules (module_type_id, title, page_id, content, category) VALUES (1, "color1", 1, "red", 1);
+INSERT IGNORE INTO modules (module_type_id, title, page_id, content, category) VALUES (1, "color2", 1, "blue", 1);
+INSERT IGNORE INTO modules (module_type_id, title, page_id, content, category) VALUES (1, "color3", 1, "green", 1);
 
 CREATE TABLE IF NOT EXISTS web_config (
     config_key VARCHAR(100) PRIMARY KEY NOT NULL,

--- a/src/controllers/page_controllers.rs
+++ b/src/controllers/page_controllers.rs
@@ -6,14 +6,14 @@ use handlebars::Handlebars;
 
 use crate::models::{pool_handler, Joinable, Model, MySQLPool};
 
-use crate::models::module_models::Module;
+use crate::models::module_models::{Module, ModuleCategory};
 use crate::models::page_models::PageModuleDTO;
 use crate::models::page_models::{MutPage, Page};
 
 use crate::middleware::errors_middleware::CustomHttpError;
 use crate::middleware::response_middleware::HttpResponseBuilder;
 
-fn parse_page(page: (Page, Vec<Module>)) -> Result<PageModuleDTO, CustomHttpError> {
+fn parse_page(page: (Page, Vec<(&Vec<Module>, &ModuleCategory)>, Vec<Module>)) -> Result<PageModuleDTO, CustomHttpError> {
     let origin_page = page.0;
 
     // cast the origin page that is always standard into a new object that has the modules as a vec of children.
@@ -22,13 +22,20 @@ fn parse_page(page: (Page, Vec<Module>)) -> Result<PageModuleDTO, CustomHttpErro
         page_url: origin_page.page_url.to_string(),
         page_title: origin_page.page_title.to_string(),
         time_created: origin_page.time_created,
-        fields: HashMap::new(),
         page_id: origin_page.id,
+        fields: HashMap::new(),
+        array_fields: HashMap::new(),
     };
 
     for module in page.1 {
+        res.array_fields.insert(module.1.title, module.0.clone());
+    }
+
+    for module in page.2 {
         res.fields.insert(module.title.clone(), module);
     }
+
+
 
     Ok(res)
 }

--- a/src/controllers/page_controllers.rs
+++ b/src/controllers/page_controllers.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 use actix_web::{web, HttpResponse};
 use handlebars::Handlebars;
 
-use crate::models::{pool_handler, Joinable, Model, MySQLPool};
+use crate::models::{pool_handler, Model, MySQLPool};
 
 use crate::models::module_models::{Module, ModuleCategory};
 use crate::models::page_models::PageModuleDTO;
@@ -13,7 +13,7 @@ use crate::models::page_models::{MutPage, Page};
 use crate::middleware::errors_middleware::CustomHttpError;
 use crate::middleware::response_middleware::HttpResponseBuilder;
 
-fn parse_page(page: (Page, Vec<(&Vec<Module>, &ModuleCategory)>, Vec<Module>)) -> Result<PageModuleDTO, CustomHttpError> {
+fn parse_page(page: (Page, Vec<(Vec<Module>, ModuleCategory)>, Vec<Module>)) -> Result<PageModuleDTO, CustomHttpError> {
     let origin_page = page.0;
 
     // cast the origin page that is always standard into a new object that has the modules as a vec of children.
@@ -28,7 +28,7 @@ fn parse_page(page: (Page, Vec<(&Vec<Module>, &ModuleCategory)>, Vec<Module>)) -
     };
 
     for module in page.1 {
-        res.array_fields.insert(module.1.title, module.0.clone());
+        res.array_fields.insert(module.1.title.clone(), module.0.clone());
     }
 
     for module in page.2 {

--- a/src/helpers/default.rs
+++ b/src/helpers/default.rs
@@ -39,6 +39,9 @@ fn get(
     Ok(())
 }
 
+/// For this helper, we need to return ScopedJson.
+/// The #each operator does not accept a string as an argument, and normal helpers are meant to write strings.
+/// With such, we use the handlebars HelperDef object that allows us to return ScopedJson.
 #[derive(Clone, Copy)]
 pub struct ArrayHelper;
 
@@ -48,7 +51,7 @@ impl HelperDef for ArrayHelper {
         h: &Helper<'reg, 'rc>,
         _: &'reg Handlebars<'reg>,
         ctx: &'rc Context,
-        rc: &mut RenderContext<'reg, 'rc>,
+        _: &mut RenderContext<'reg, 'rc>,
     ) -> Result<Option<ScopedJson<'reg, 'rc>>, RenderError> {
         let module_title = h
             .param(0)

--- a/src/helpers/default.rs
+++ b/src/helpers/default.rs
@@ -1,6 +1,6 @@
-use std::sync::Mutex;
 use actix_web::web::Data;
 use handlebars::{Context, Handlebars, Helper, JsonRender, Output, RenderContext, RenderError};
+use std::sync::Mutex;
 
 fn get(
     h: &Helper,
@@ -19,8 +19,7 @@ fn get(
     // helper that allows a custom error message to show if the value does not exist in the database yet.
     // errors are passed up through `ok_or` returning a RenderError, then passed to the `try` block.
     let field_result: Result<String, RenderError> = try {
-        ctx
-            .data()
+        ctx.data()
             .get("fields")
             .ok_or(RenderError::new("No fields exist on this page."))?
             .get(module_title.clone())

--- a/src/models/page_models.rs
+++ b/src/models/page_models.rs
@@ -1,11 +1,14 @@
-use std::collections::HashMap;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
-use super::Joinable;
 use super::module_models::Module;
+use super::Joinable;
 use super::Model;
+use crate::models::module_models::ModuleCategory;
+use crate::schema::module_category;
+use crate::schema::modules;
 use crate::schema::pages;
 
 #[derive(Identifiable, Debug, Serialize, Deserialize, Queryable, PartialEq, Clone)]
@@ -38,6 +41,7 @@ pub struct PageModuleDTO {
     /// the key of the hashmap is the `title` of the module, and the rest is the module.
     /// For the usefulness of this, see the `get` function on the default helpers.
     pub fields: HashMap<String, Module>,
+    pub array_fields: HashMap<String, Vec<Module>>,
 }
 
 impl Model<Page, MutPage, i32> for Page {
@@ -79,18 +83,31 @@ impl Model<Page, MutPage, i32> for Page {
     }
 }
 
-impl Joinable<Page, Module, String> for Page {
-    fn read_one_join_on(
+impl Page {
+    pub fn read_one_join_on(
         id: String,
         db: &MysqlConnection,
-    ) -> Result<(Self, Vec<Module>), diesel::result::Error> {
+    ) -> Result<(Self, Vec<(&Vec<Module>, &ModuleCategory)>, Vec<Module>), diesel::result::Error> {
         use crate::schema::pages::dsl::page_url;
 
         let filtered_page = pages::table.filter(page_url.eq(id)).first::<Page>(db)?;
 
-        let modules = Module::belonging_to(&filtered_page)
-            .load::<Module>(db)?;
+        let modules = Module::belonging_to(&filtered_page).load::<Module>(db)?;
 
-        Ok((filtered_page, modules))
+        let categories = Module::belonging_to(&filtered_page)
+            .inner_join(module_category::table)
+            .select(module_category::all_columns)
+            .load::<ModuleCategory>(db)?;
+
+        let module_array = Module::belonging_to(&categories)
+            .load::<Module>(db)?
+            .grouped_by(&categories)
+            .iter()
+            .zip(&categories)
+            .collect::<Vec<_>>();
+
+        
+
+        Ok((filtered_page, module_array, modules))
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,11 @@
 table! {
+    module_category (id) {
+        id -> Integer,
+        title -> Varchar,
+    }
+}
+
+table! {
     module_types (module_type_id) {
         module_type_id -> Integer,
         title -> Varchar,
@@ -13,6 +20,7 @@ table! {
         title -> Varchar,
         page_id -> Integer,
         content -> Text,
+        category -> Nullable<Integer>,
     }
 }
 
@@ -33,10 +41,12 @@ table! {
     }
 }
 
+joinable!(modules -> module_category (category));
 joinable!(modules -> module_types (module_type_id));
 joinable!(modules -> pages (page_id));
 
 allow_tables_to_appear_in_same_query!(
+    module_category,
     module_types,
     modules,
     pages,

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,13 +17,13 @@
 
     <br>
 
-    {{#each (lookup ../array_fields "colors") as |t| }}
+    {{#each (getarray "colors") as |t| }}
         <div class="card d-flex flex-column p-5 m-2 w-25">
             <div class="card-body">
                 <h5 class="card-title">Title: {{t.title}}</h5>
                 <p class="card-text">Name: {{t.content}}</p>
+                <small>{{@index}}</small>
             </div>
-            
         </div>
         {{else}}
         <p>WRONG</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,13 +11,14 @@
 
 <body>
     <h1>{{ page_title }}</h1>
+    <hr>
     <h1>{{get "title"}}</h1>
     <small>{{get "small"}}</small>
 
     <br>
 
-    {{#each (lookup ../array_fields "friends") as |t| }}
-        <div class="card d-flex flex-column p-5 m-5 w-25">
+    {{#each (lookup ../array_fields "colors") as |t| }}
+        <div class="card d-flex flex-column p-5 m-2 w-25">
             <div class="card-body">
                 <h5 class="card-title">Title: {{t.title}}</h5>
                 <p class="card-text">Name: {{t.content}}</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,8 +10,10 @@
 
 <body>
     <h1>{{ page_title }}</h1>
-    <p>{{get "title"}}</p>
     <small>{{get "small"}}</small>
+    {{#each getarray "title"}}
+        <p>{{this}}</p>
+    {{/each}}
 </body>
 
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,14 +5,27 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="./assets/main.css">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <title>{{ page_title }}</title>
 </head>
 
 <body>
     <h1>{{ page_title }}</h1>
+    <h1>{{get "title"}}</h1>
     <small>{{get "small"}}</small>
-    {{#each getarray "title"}}
-        <p>{{this}}</p>
+
+    <br>
+
+    {{#each (lookup ../array_fields "friends") as |t| }}
+        <div class="card d-flex flex-column p-5 m-5 w-25">
+            <div class="card-body">
+                <h5 class="card-title">Title: {{t.title}}</h5>
+                <p class="card-text">Name: {{t.content}}</p>
+            </div>
+            
+        </div>
+        {{else}}
+        <p>WRONG</p>
     {{/each}}
 </body>
 


### PR DESCRIPTION
Code example:

```handlebars
{{#each (getarray "colors") as |t| }}
    <div class="card d-flex flex-column p-5 m-2 w-25">
        <div class="card-body">
            <h5 class="card-title">Title: {{t.title}}</h5>
            <p class="card-text">Name: {{t.content}}</p>
            <small>{{@index}}</small>
        </div>
    </div>
    {{else}}
    <p>WRONG</p>
{{/each}}
```

The `getarray` helper accesses the `array_fields` field on the data of the template. `array_fields` is a hashmap. We access the correct array by the argument of the `getarray` helper.